### PR TITLE
TreeView: доработки для древовидной структуры

### DIFF
--- a/lib/components/ui/tree-view.tsx
+++ b/lib/components/ui/tree-view.tsx
@@ -44,6 +44,8 @@ export interface TreeViewConfig<T extends TreeNode> {
   isNodeExpanded: (node: T) => boolean;
   isNodeSelected: (node: T, selected: unknown) => boolean;
   getNodeHeadingText: (node: T) => string | number | undefined;
+  /** Контент перед иконкой раскрытия в колонке названия (например чекбокс). */
+  getNodeHeadingPrefix?: (node: T) => ReactNode;
   getNodeFooterText: (node: T) => string | undefined;
   getNodeCellValues: (node: T) => ReactNode[];
   getNodeHeadingClassName?: (node: T) => string | undefined;
@@ -57,6 +59,12 @@ export interface TreeViewConfig<T extends TreeNode> {
   getNodeFooterClassName?: (node: T) => string | undefined;
   renderTooltip?: (node: T) => ReactNode;
   renderExpandIcon?: (node: T, isExpanded: boolean, onClick: () => void) => ReactNode;
+  /** Ширина колонки направляющих дерева, px (по умолчанию 24). */
+  treeGuideColumnWidth?: number;
+  /** Смещение якоря линии от начала контентной области, px (по умолчанию половина treeGuideColumnWidth). */
+  treeLineAnchorOffset?: number;
+  /** Вертикальная позиция соединительной линии в строке (по умолчанию середина строки). */
+  treeLineAnchorTop?: number | string;
 }
 
 /**
@@ -86,6 +94,8 @@ export interface TreeViewProps<T extends TreeNode> {
   selected?: unknown;
   config: TreeViewConfig<T>;
   headers?: string[];
+  /** Кастомные ячейки заголовка (например FiltersColumnHeader). Приоритетнее headers. */
+  headerCells?: ReactNode[];
   className?: string;
   columnWidths?: (number | string)[];
   columnAlignments?: ('left' | 'center' | 'right')[];
@@ -103,56 +113,21 @@ export interface TreeViewProps<T extends TreeNode> {
   scrollElementRef?: RefObject<HTMLDivElement>;
   /** ID для scroll-контейнера (для синхронизации скролла с другими элементами) */
   scrollContainerId?: string;
+  /** Чередование фона строк, как в DataTable */
+  striped?: boolean;
+  /** Горизонтальные отступы ячеек, как в DataTable; `none` — без доп. отступов (узкие деревья навигации) */
+  horizontalPadding?: 'none' | 'small' | 'medium' | 'large';
+  /** `compact` — плотные строки без отступов DataTable (дерево настроек Toro) */
+  density?: 'default' | 'compact';
   /**
    * Если задан, подменяет содержимое первой ячейки заголовка (например, заголовок + кнопка).
-   * Остальные колонки по-прежнему из `headers`.
+   * Остальные колонки по-прежнему из `headers`. Не используется вместе с `headerCells`.
    */
   renderFirstColumnHeader?: ReactNode;
 }
 
 /**
  * TreeView - компонент для отображения иерархических данных в табличном формате.
- *
- * @component
- * @template T - Тип узла дерева, должен расширять TreeNode
- * @param {TreeViewProps<T>} props - Параметры компонента
- * @param {T[]} props.nodes - Массив узлов дерева для отображения. Каждый узел может содержать onClick и onDoubleClick
- * @param {unknown} [props.selected] - Текущий выбранный узел
- * @param {function} props.onExpand - Обработчик разворачивания/сворачивания узла
- * @param {TreeViewConfig<T>} props.config - Конфигурация для работы с узлами дерева
- * @param {string[]} [props.headers] - Заголовки колонок таблицы
- * @param {string} [props.className] - Дополнительные CSS-классы для контейнера
- * @param {(number|string)[]} [props.columnWidths] - Ширины колонок (px или строка с единицами)
- * @param {('left'|'center'|'right')[]} [props.columnAlignments] - Выравнивание содержимого колонок
- * @returns {React.ReactElement} Компонент TreeView
- *
- * @example
- * ```tsx
- * const config: TreeViewConfig<MyNode> = {
- *   getNodeId: (node) => node.id,
- *   getNodeLevel: (node) => node.level ?? 0,
- *   getNodeChildren: (node) => node.children,
- *   hasNestedNodes: (node) => !!node.children?.length,
- *   isNodeExpanded: (node) => node.expanded,
- *   isNodeSelected: (node, selected) => node.id === selected,
- *   getNodeHeadingText: (node) => node.name,
- *   getNodeFooterText: (node) => node.description,
- *   getNodeCellValues: (node) => [node.value1, node.value2],
- * };
- *
- * const nodes = myNodes.map(node => ({
- *   ...node,
- *   onClick: node.hasAction ? () => handleClick(node) : undefined,
- * }));
- *
- * <TreeView
- *   nodes={nodes}
- *   selected={selectedId}
- *   onExpand={handleExpand}
- *   config={config}
- *   headers={['Название', 'Значение 1', 'Значение 2']}
- * />
- * ```
  */
 export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
   const {
@@ -160,6 +135,7 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
     selected,
     config,
     headers,
+    headerCells,
     className,
     columnWidths,
     columnAlignments,
@@ -170,76 +146,77 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
     overscan = 20,
     scrollElementRef: externalScrollRef,
     scrollContainerId,
+    striped = false,
+    horizontalPadding = 'medium',
+    density = 'default',
     renderFirstColumnHeader,
   } = props;
 
   const Tr = (TableRowFromProps ?? DefaultTableRow) as TreeViewTableRowComponent<T>;
 
-  const internalScrollRef = useRef<HTMLDivElement | null>(null);
-  const scrollRef = (externalScrollRef ?? internalScrollRef) as RefObject<HTMLDivElement>;
+  const isCompact = density === 'compact';
 
-  // Flatten visible nodes for virtualization
-  const flattenedNodesWithGuides = useMemo(() => {
-    if (!virtualized) return [];
-
-    type FlatNode = { node: T; guides: boolean[]; isLastChild: boolean; skipGuides: boolean[] };
-    const result: FlatNode[] = [];
-
-    const traverse = (nodeList: T[], guides: boolean[] = [], skipGuides: boolean[] = []) => {
-      nodeList.forEach((node, index) => {
-        const isLastChild = index === nodeList.length - 1;
-        const level = config.getNodeLevel(node);
-        result.push({ node, guides, isLastChild, skipGuides });
-
-        const children = config.getNodeChildren(node);
-        const isExpanded = config.isNodeExpanded(node);
-
-        if (children?.length && isExpanded) {
-          const newSkipGuides = new Array(level + 1).fill(false);
-          for (let i = 0; i < level - 1; i++) {
-            newSkipGuides[i] = skipGuides[i] || false;
-          }
-          if (isLastChild && level > 0) {
-            newSkipGuides[level - 1] = true;
-          }
-          traverse(children, [...guides, true], newSkipGuides);
-        }
-      });
-    };
-
-    traverse(nodes);
-    return result;
-  }, [nodes, virtualized, config]);
-
-  const virtualizer = useVirtualizer({
-    count: virtualized ? flattenedNodesWithGuides.length : 0,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => estimateRowSize,
-    overscan,
-  });
-
-  const virtualItems = virtualized ? virtualizer.getVirtualItems() : [];
-
-  const paddingTop = virtualized ? virtualItems[0]?.start ?? 0 : 0;
-  const paddingBottom = virtualized
-    ? virtualizer.getTotalSize() - (virtualItems[virtualItems.length - 1]?.end ?? 0)
-    : 0;
-
-  const getColumnWidth = (index: number): CSSProperties | undefined => {
-    if (!columnWidths || !columnWidths[index]) return undefined;
-    const width = columnWidths[index];
-    return {
-      width: typeof width === 'number' ? `${width}px` : width,
-      maxWidth: typeof width === 'number' ? `${width}px` : width,
-      minWidth: typeof width === 'number' ? `${width}px` : width,
-    };
+  const getFirstColumnPadding = () => {
+    switch (horizontalPadding) {
+      case 'none':
+        return '';
+      case 'small':
+        return 'pl-4';
+      case 'large':
+        return 'pl-8';
+      case 'medium':
+      default:
+        return 'pl-6';
+    }
   };
 
-  const getColumnAlignment = (index: number): 'left' | 'center' | 'right' => {
-    if (!columnAlignments || !columnAlignments[index]) {
-      return index === 0 ? 'left' : 'center';
+  const getLastColumnPadding = () => {
+    switch (horizontalPadding) {
+      case 'none':
+        return '';
+      case 'small':
+        return 'pr-4';
+      case 'large':
+        return 'pr-8';
+      case 'medium':
+      default:
+        return 'pr-6';
     }
-    return columnAlignments[index];
+  };
+
+  const getRowContentClassName = () =>
+    cn(
+      'relative flex min-w-0 flex-1',
+      isCompact ? 'items-center py-[3px]' : 'items-stretch py-2',
+    );
+
+  const getHeadingTextClassName = (node: T, shouldShowCursor: boolean) =>
+    cn(
+      'truncate font-normal text-foreground-primary',
+      isCompact ? 'text-xs leading-4' : 'text-sm leading-5',
+      {
+        'cursor-pointer': shouldShowCursor,
+      },
+      config.getNodeHeadingClassName?.(node),
+    );
+
+  const getRowClassName = (rowIndex: number, isSelected: boolean) =>
+    cn(
+      'transition-colors hover:bg-background-primary-hover',
+      striped && rowIndex % 2 === 1 && 'bg-background-secondary',
+      isSelected && 'bg-background-primary-selected',
+    );
+
+  const getTreeGuideWidth = () => config.treeGuideColumnWidth ?? 24;
+  const getTreeLineAnchorOffset = () =>
+    config.treeLineAnchorOffset ?? getTreeGuideWidth() / 2;
+  const getTreeLineAnchorTop = () => {
+    const anchorTop = config.treeLineAnchorTop ?? '50%';
+    return typeof anchorTop === 'number' ? `${anchorTop}px` : anchorTop;
+  };
+  const getTreeGuideColumnStyle = (): CSSProperties => {
+    const width = getTreeGuideWidth();
+    return { width, minWidth: width, maxWidth: width };
   };
 
   const renderDefaultExpandIcon = (
@@ -284,6 +261,250 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
     );
   };
 
+  const renderTreeGuideColumns = (
+    level: number,
+    guides: boolean[],
+    isLastChild: boolean,
+    skipGuides: boolean[],
+  ) =>
+    Array.from({ length: level }).map((_, i) => (
+      <div key={i} className='relative flex-shrink-0' style={getTreeGuideColumnStyle()}>
+        {guides[i] && i !== level - 1 && !skipGuides[i] && (
+          <div className='absolute left-1/2 top-0 bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast' />
+        )}
+        {i === level - 1 && (
+          <>
+            <div
+              className='absolute left-1/2 top-0 w-[1px] -translate-x-1/2 bg-line-contrast'
+              style={{ height: getTreeLineAnchorTop() }}
+            />
+            <div
+              className='absolute h-[1px] bg-line-contrast'
+              style={{
+                top: getTreeLineAnchorTop(),
+                left: '50%',
+                width: `calc(50% + ${getTreeLineAnchorOffset()}px)`,
+              }}
+            />
+            {!isLastChild && (
+              <div
+                className='absolute left-1/2 bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast'
+                style={{ top: getTreeLineAnchorTop() }}
+              />
+            )}
+          </>
+        )}
+      </div>
+    ));
+
+  const renderTreeHeadingControls = (
+    node: T,
+    hasNested: boolean,
+    isExpanded: boolean,
+    shouldShowCursor: boolean,
+    headingText: string | number | undefined,
+    headingMaxLength: number | undefined,
+    footerText: string | undefined,
+    children: T[] | undefined,
+  ) => (
+    <div className='flex min-w-0 flex-1 items-center'>
+      {config.getNodeHeadingPrefix?.(node) ? (
+        <div
+          className='relative z-10 mr-1 flex shrink-0 self-stretch'
+          style={getTreeGuideColumnStyle()}>
+          <div className='flex items-center justify-center' style={getTreeGuideColumnStyle()}>
+            {config.getNodeHeadingPrefix(node)}
+          </div>
+          {hasNested && isExpanded && (
+            <div
+              className='absolute left-1/2 w-[1px] -translate-x-1/2 bg-line-contrast'
+              style={{ top: '17px', bottom: '-8px' }}
+            />
+          )}
+        </div>
+      ) : null}
+      {!config.getNodeHeadingPrefix && !!children?.length && isExpanded && (
+        <div
+          className='absolute bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast'
+          style={{ top: getTreeLineAnchorTop(), left: getTreeLineAnchorOffset() }}
+        />
+      )}
+      <div className='relative z-10 flex shrink-0'>
+        {config.renderExpandIcon
+          ? config.renderExpandIcon(node, isExpanded, () => onExpand(node))
+          : renderDefaultExpandIcon(hasNested, isExpanded, () => onExpand(node))}
+      </div>
+      <div className='ml-2 flex min-w-0 flex-col gap-[2px]'>
+        {config.renderTooltip ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className={getHeadingTextClassName(node, shouldShowCursor)}
+                  style={headingMaxLength ? { maxWidth: `${headingMaxLength}ch` } : undefined}>
+                  {headingText}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className='max-w-[300px]'>{config.renderTooltip(node)}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <span
+            className={getHeadingTextClassName(node, shouldShowCursor)}
+            style={headingMaxLength ? { maxWidth: `${headingMaxLength}ch` } : undefined}
+            title={String(headingText ?? '')}>
+            {headingText}
+          </span>
+        )}
+        {renderFooter(node, footerText)}
+      </div>
+    </div>
+  );
+
+  const visibleRowIndexByNodeId = useMemo(() => {
+    const map = new Map<number | string, number>();
+    let index = 0;
+
+    const traverse = (nodeList: T[]) => {
+      nodeList.forEach(node => {
+        map.set(config.getNodeId(node), index);
+        index += 1;
+
+        const children = config.getNodeChildren(node);
+        if (children?.length && config.isNodeExpanded(node)) {
+          traverse(children);
+        }
+      });
+    };
+
+    traverse(nodes);
+    return map;
+  }, [nodes, config]);
+
+  const internalScrollRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = (externalScrollRef ?? internalScrollRef) as RefObject<HTMLDivElement>;
+
+  const flattenedNodesWithGuides = useMemo(() => {
+    if (!virtualized) return [];
+
+    type FlatNode = { node: T; guides: boolean[]; isLastChild: boolean; skipGuides: boolean[] };
+    const result: FlatNode[] = [];
+
+    const traverse = (nodeList: T[], guides: boolean[] = [], skipGuides: boolean[] = []) => {
+      nodeList.forEach((node, index) => {
+        const isLastChild = index === nodeList.length - 1;
+        const level = config.getNodeLevel(node);
+        result.push({ node, guides, isLastChild, skipGuides });
+
+        const children = config.getNodeChildren(node);
+        const isExpanded = config.isNodeExpanded(node);
+
+        if (children?.length && isExpanded) {
+          const newSkipGuides = new Array(level + 1).fill(false);
+          for (let i = 0; i < level - 1; i++) {
+            newSkipGuides[i] = skipGuides[i] || false;
+          }
+          if (isLastChild && level > 0) {
+            newSkipGuides[level - 1] = true;
+          }
+          traverse(children, [...guides, true], newSkipGuides);
+        }
+      });
+    };
+
+    traverse(nodes);
+    return result;
+  }, [nodes, virtualized, config]);
+
+  const virtualizer = useVirtualizer({
+    count: virtualized ? flattenedNodesWithGuides.length : 0,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => estimateRowSize,
+    overscan,
+  });
+
+  const virtualItems = virtualized ? virtualizer.getVirtualItems() : [];
+
+  const paddingTop = virtualized ? (virtualItems[0]?.start ?? 0) : 0;
+  const paddingBottom = virtualized
+    ? virtualizer.getTotalSize() - (virtualItems[virtualItems.length - 1]?.end ?? 0)
+    : 0;
+
+  const getColumnWidth = (index: number): CSSProperties | undefined => {
+    if (!columnWidths || !columnWidths[index]) return undefined;
+    const width = columnWidths[index];
+    return {
+      width: typeof width === 'number' ? `${width}px` : width,
+      maxWidth: typeof width === 'number' ? `${width}px` : width,
+      minWidth: typeof width === 'number' ? `${width}px` : width,
+    };
+  };
+
+  const getColumnAlignment = (index: number): 'left' | 'center' | 'right' => {
+    if (!columnAlignments || !columnAlignments[index]) {
+      return index === 0 ? 'left' : 'center';
+    }
+    return columnAlignments[index];
+  };
+
+  const renderFirstColumnCell = (
+    node: T,
+    level: number,
+    guides: boolean[],
+    isLastChild: boolean,
+    skipGuides: boolean[],
+    hasNested: boolean,
+    isExpanded: boolean,
+    shouldShowCursor: boolean,
+    headingText: string | number | undefined,
+    headingMaxLength: number | undefined,
+    footerText: string | undefined,
+    children: T[] | undefined,
+    cellValues: ReactNode[],
+  ) => (
+    <td
+      className={cn('border-r border-line-primary p-0', {
+        'border-r-0': cellValues.length === 0,
+      })}
+      style={getColumnWidth(0)}>
+      <div className={cn('flex items-stretch', getFirstColumnPadding())}>
+        {renderTreeGuideColumns(level, guides, isLastChild, skipGuides)}
+        <div className={getRowContentClassName()}>
+          {renderTreeHeadingControls(
+            node,
+            hasNested,
+            isExpanded,
+            shouldShowCursor,
+            headingText,
+            headingMaxLength,
+            footerText,
+            children,
+          )}
+        </div>
+      </div>
+    </td>
+  );
+
+  const renderDataCells = (cellValues: ReactNode[]) =>
+    cellValues.map((value, cellIndex) => (
+      <td
+        key={cellIndex}
+        className={cn(
+          'border-r border-line-primary align-middle text-foreground-primary',
+          isCompact ? 'py-[3px]' : 'p-2',
+          {
+            'text-left': getColumnAlignment(cellIndex + 1) === 'left',
+            'text-center': getColumnAlignment(cellIndex + 1) === 'center',
+            'text-right': getColumnAlignment(cellIndex + 1) === 'right',
+            'border-r-0': cellIndex === cellValues.length - 1,
+          },
+          cellIndex === cellValues.length - 1 && getLastColumnPadding(),
+        )}
+        style={getColumnWidth(cellIndex + 1)}>
+        {value}
+      </td>
+    ));
+
   const renderSingleRow = (
     node: T,
     guides: boolean[],
@@ -305,6 +526,7 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
     const cellValues = config.getNodeCellValues(node);
 
     const shouldShowCursor = !!(node.onClick || node.onDoubleClick);
+    const rowIndex = rowKey !== undefined ? Number(rowKey) : (visibleRowIndexByNodeId.get(nodeId) ?? 0);
 
     return (
       <Tr
@@ -312,108 +534,25 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
         ref={measureRef}
         data-index={rowKey}
         node={node}
-        className='group'
+        className={cn('group', getRowClassName(rowIndex, isSelected))}
         onClick={() => node.onClick?.()}
-        onDoubleClick={() => node.onDoubleClick?.()}
-      >
-        <td
-          className={cn(
-            'p-0 border-r border-line-primary group-hover:bg-background-primary-selected transition-colors',
-            {
-              'bg-background-primary-selected': isSelected,
-              'border-r-0': cellValues.length === 0,
-            },
-          )}
-          style={getColumnWidth(0)}
-        >
-          <div className='flex items-stretch'>
-            {Array.from({ length: level }).map((_, i) => (
-              <div key={i} className='relative w-6 flex-shrink-0'>
-                {guides[i] && !(i === level - 1 && isLastChild) && !skipGuides[i] && (
-                  <div className='absolute left-1/2 top-0 bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast' />
-                )}
-                {i === level - 1 && (
-                  <>
-                    <div className='absolute left-1/2 top-0 h-1/2 w-[1px] -translate-x-1/2 bg-line-contrast' />
-                    <div className='absolute left-1/2 top-1/2 h-[1px] w-1/2 bg-line-contrast' />
-                    {!isLastChild && (
-                      <div className='absolute left-1/2 top-1/2 bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast' />
-                    )}
-                  </>
-                )}
-              </div>
-            ))}
-
-            <div className='flex items-center py-[3px] flex-1 min-w-0 relative'>
-              {!!children?.length && isExpanded && (
-                <div className='absolute left-3 top-1/2 bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast' />
-              )}
-              <div className='relative z-10 flex'>
-                {config.renderExpandIcon
-                  ? config.renderExpandIcon(node, isExpanded, () => onExpand(node))
-                  : renderDefaultExpandIcon(hasNested, isExpanded, () => onExpand(node))}
-              </div>
-              <div className='flex flex-col gap-[2px] min-w-0 ml-2'>
-                {config.renderTooltip ? (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span
-                          className={cn(
-                            'text-foreground-primary text-xs font-normal leading-4 truncate',
-                            {
-                              'cursor-pointer': shouldShowCursor,
-                            },
-                            config.getNodeHeadingClassName?.(node),
-                          )}
-                          style={
-                            headingMaxLength ? { maxWidth: `${headingMaxLength}ch` } : undefined
-                          }
-                        >
-                          {headingText}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent className='max-w-[300px]'>{config.renderTooltip(node)}</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                ) : (
-                  <span
-                    className={cn(
-                      'text-foreground-primary text-xs font-normal leading-4 truncate',
-                      {
-                        'cursor-pointer': shouldShowCursor,
-                      },
-                      config.getNodeHeadingClassName?.(node),
-                    )}
-                    style={headingMaxLength ? { maxWidth: `${headingMaxLength}ch` } : undefined}
-                    title={String(headingText ?? '')}
-                  >
-                    {headingText}
-                  </span>
-                )}
-                {renderFooter(node, footerText)}
-              </div>
-            </div>
-          </div>
-        </td>
-        {cellValues.map((value, index) => (
-          <td
-            key={index}
-            className={cn(
-              'py-[3px] align-middle border-r border-line-primary group-hover:bg-background-primary-selected transition-colors',
-              {
-                'text-left': getColumnAlignment(index + 1) === 'left',
-                'text-center': getColumnAlignment(index + 1) === 'center',
-                'text-right': getColumnAlignment(index + 1) === 'right',
-                'bg-background-primary-selected': isSelected,
-                'border-r-0': index === cellValues.length - 1,
-              },
-            )}
-            style={getColumnWidth(index + 1)}
-          >
-            {value}
-          </td>
-        ))}
+        onDoubleClick={() => node.onDoubleClick?.()}>
+        {renderFirstColumnCell(
+          node,
+          level,
+          guides,
+          isLastChild,
+          skipGuides,
+          hasNested,
+          isExpanded,
+          shouldShowCursor,
+          headingText,
+          headingMaxLength,
+          footerText,
+          children,
+          cellValues,
+        )}
+        {renderDataCells(cellValues)}
       </Tr>
     );
   };
@@ -436,119 +575,32 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
       const cellValues = config.getNodeCellValues(node);
 
       const isLastChild = index === nodesToRender.length - 1;
-
       const shouldShowCursor = !!(node.onClick || node.onDoubleClick);
+      const rowIndex = visibleRowIndexByNodeId.get(nodeId) ?? 0;
 
       return (
         <Fragment key={nodeId}>
           <Tr
             node={node}
-            className='group'
+            className={cn('group', getRowClassName(rowIndex, isSelected))}
             onClick={() => node.onClick?.()}
-            onDoubleClick={() => node.onDoubleClick?.()}
-          >
-            <td
-              className={cn(
-                'p-0 border-r border-line-primary group-hover:bg-background-primary-selected transition-colors',
-                {
-                  'bg-background-primary-selected': isSelected,
-                  'border-r-0': cellValues.length === 0,
-                },
-              )}
-              style={getColumnWidth(0)}
-            >
-              <div className='flex items-stretch'>
-                {Array.from({ length: level }).map((_, i) => (
-                  <div key={i} className='relative w-6 flex-shrink-0'>
-                    {guides[i] && !(i === level - 1 && isLastChild) && !skipGuides[i] && (
-                      <div className='absolute left-1/2 top-0 bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast' />
-                    )}
-                    {i === level - 1 && (
-                      <>
-                        <div className='absolute left-1/2 top-0 h-1/2 w-[1px] -translate-x-1/2 bg-line-contrast' />
-                        <div className='absolute left-1/2 top-1/2 h-[1px] w-1/2 bg-line-contrast' />
-                        {!isLastChild && (
-                          <div className='absolute left-1/2 top-1/2 bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast' />
-                        )}
-                      </>
-                    )}
-                  </div>
-                ))}
-
-                <div className='flex items-center py-[3px] flex-1 min-w-0 relative'>
-                  {!!children?.length && isExpanded && (
-                    <div className='absolute left-3 top-1/2 bottom-0 w-[1px] -translate-x-1/2 bg-line-contrast' />
-                  )}
-                  <div className='relative z-10 flex'>
-                    {config.renderExpandIcon
-                      ? config.renderExpandIcon(node, isExpanded, () => onExpand(node))
-                      : renderDefaultExpandIcon(hasNested, isExpanded, () => onExpand(node))}
-                  </div>
-                  <div className='flex flex-col gap-[2px] min-w-0 ml-2'>
-                    {config.renderTooltip ? (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span
-                              className={cn(
-                                'text-foreground-primary text-xs font-normal leading-4 truncate',
-                                {
-                                  'cursor-pointer': shouldShowCursor,
-                                },
-                                config.getNodeHeadingClassName?.(node),
-                              )}
-                              style={
-                                headingMaxLength ? { maxWidth: `${headingMaxLength}ch` } : undefined
-                              }
-                            >
-                              {headingText}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent className='max-w-[300px]'>
-                            {config.renderTooltip(node)}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    ) : (
-                      <span
-                        className={cn(
-                          'text-foreground-primary text-xs font-normal leading-4 truncate',
-                          {
-                            'cursor-pointer': shouldShowCursor,
-                          },
-                          config.getNodeHeadingClassName?.(node),
-                        )}
-                        style={
-                          headingMaxLength ? { maxWidth: `${headingMaxLength}ch` } : undefined
-                        }
-                        title={String(headingText ?? '')}
-                      >
-                        {headingText}
-                      </span>
-                    )}
-                    {renderFooter(node, footerText)}
-                  </div>
-                </div>
-              </div>
-            </td>
-            {cellValues.map((value, cellIndex) => (
-              <td
-                key={cellIndex}
-                className={cn(
-                  'py-[3px] align-middle border-r border-line-primary group-hover:bg-background-primary-selected transition-colors',
-                  {
-                    'text-left': getColumnAlignment(cellIndex + 1) === 'left',
-                    'text-center': getColumnAlignment(cellIndex + 1) === 'center',
-                    'text-right': getColumnAlignment(cellIndex + 1) === 'right',
-                    'bg-background-primary-selected': isSelected,
-                    'border-r-0': cellIndex === cellValues.length - 1,
-                  },
-                )}
-                style={getColumnWidth(cellIndex + 1)}
-              >
-                {value}
-              </td>
-            ))}
+            onDoubleClick={() => node.onDoubleClick?.()}>
+            {renderFirstColumnCell(
+              node,
+              level,
+              guides,
+              isLastChild,
+              skipGuides,
+              hasNested,
+              isExpanded,
+              shouldShowCursor,
+              headingText,
+              headingMaxLength,
+              footerText,
+              children,
+              cellValues,
+            )}
+            {renderDataCells(cellValues)}
           </Tr>
           {!!children?.length &&
             isExpanded &&
@@ -568,49 +620,70 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
   };
 
   const headersArray = headers || [];
-  const hasHeaders = headersArray.length > 0 && headersArray.some(header => header.trim() !== '');
-  const showThead = hasHeaders || renderFirstColumnHeader !== undefined;
+  const headerItems = headerCells ?? headersArray;
+  const hasHeaderLabels =
+    headerItems.length > 0 &&
+    headerItems.some(header =>
+      headerCells ? header !== null && header !== undefined : String(header).trim() !== '',
+    );
+  const showThead = hasHeaderLabels || renderFirstColumnHeader !== undefined;
+  const columnCount = headerCells ? headerItems.length || 1 : Math.max(headersArray.length, 1);
+
+  const thClassName = (index: number, isLast: boolean) =>
+    cn(
+      'box-border min-h-9 overflow-hidden border-b border-r border-line-primary border-b-line-primary-disabled p-2 text-left font-medium text-foreground-primary align-middle min-w-0',
+      index === 0 && getFirstColumnPadding(),
+      isLast && cn(getLastColumnPadding(), 'border-r-0'),
+      {
+        'text-left': index === 0 || getColumnAlignment(index) === 'left',
+        'text-center': index !== 0 && getColumnAlignment(index) === 'center',
+        'text-right': index !== 0 && getColumnAlignment(index) === 'right',
+      },
+    );
 
   return (
     <div
       ref={scrollRef}
       id={scrollContainerId}
-      className={cn('h-full overflow-auto', className)}
-    >
-      <table className='w-full border-collapse'>
+      className={cn('h-full overflow-auto', className)}>
+      <table className='w-full border-collapse text-sm'>
         {showThead && (
           <thead className='sticky top-0 z-10 bg-background-secondary'>
             <tr>
-              <th
-                className={cn(
-                  'box-border px-2 h-[40px] min-w-0 text-left text-foreground-primary text-sm font-medium border-b border-r border-line-primary border-b-line-primary-disabled',
-                  {
-                    'border-r-0': headersArray.length === 1,
-                  },
-                )}
-                style={getColumnWidth(0)}
-              >
-                {renderFirstColumnHeader ?? (headersArray[0] || '')}
-              </th>
-              {headersArray.slice(1).map((header, index) => (
-                <th
-                  key={index}
-                  className={cn(
-                    'box-border px-2 h-[40px] text-foreground-primary text-sm font-medium border-b border-r border-line-primary border-b-line-primary-disabled min-w-0 overflow-hidden',
-                    {
-                      'text-left': getColumnAlignment(index + 1) === 'left',
-                      'text-center': getColumnAlignment(index + 1) === 'center',
-                      'text-right': getColumnAlignment(index + 1) === 'right',
-                      'border-r-0': index === headersArray.slice(1).length - 1,
-                    },
-                  )}
-                  style={getColumnWidth(index + 1)}
-                >
-                  <span className='block truncate' title={String(header)}>
+              {headerCells ? (
+                headerItems.map((header, index) => (
+                  <th
+                    key={index}
+                    className={thClassName(index, index === headerItems.length - 1)}
+                    style={getColumnWidth(index)}>
                     {header}
-                  </span>
-                </th>
-              ))}
+                  </th>
+                ))
+              ) : (
+                <>
+                  <th className={thClassName(0, headersArray.length <= 1)} style={getColumnWidth(0)}>
+                    {renderFirstColumnHeader ??
+                      (headersArray[0] != null && String(headersArray[0]).trim() !== '' ? (
+                        <span className='block truncate' title={String(headersArray[0])}>
+                          {headersArray[0]}
+                        </span>
+                      ) : null)}
+                  </th>
+                  {headersArray.slice(1).map((header, index) => (
+                    <th
+                      key={index + 1}
+                      className={thClassName(
+                        index + 1,
+                        index + 1 === headersArray.length - 1,
+                      )}
+                      style={getColumnWidth(index + 1)}>
+                      <span className='block truncate' title={String(header)}>
+                        {header}
+                      </span>
+                    </th>
+                  ))}
+                </>
+              )}
             </tr>
           </thead>
         )}
@@ -619,7 +692,7 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
             <>
               {paddingTop > 0 && (
                 <tr style={{ height: `${paddingTop}px` }}>
-                  <td colSpan={headersArray.length || 1} />
+                  <td colSpan={columnCount} />
                 </tr>
               )}
               {virtualItems.map(virtualRow => {
@@ -636,7 +709,7 @@ export const TreeView = <T extends TreeNode>(props: TreeViewProps<T>) => {
               })}
               {paddingBottom > 0 && (
                 <tr style={{ height: `${paddingBottom}px` }}>
-                  <td colSpan={headersArray.length || 1} />
+                  <td colSpan={columnCount} />
                 </tr>
               )}
             </>

--- a/lib/hooks/useStoredExpand.ts
+++ b/lib/hooks/useStoredExpand.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 
 export type ExpandState = Record<string | number, boolean>;
 
@@ -50,22 +50,27 @@ export const useStoredExpand = (
     readFromStorage(storageKey, storage),
   );
 
-  const setExpanded: Dispatch<SetStateAction<ExpandState>> = (updaterOrValue) => {
+  const setExpanded: Dispatch<SetStateAction<ExpandState>> = useCallback((updaterOrValue) => {
     setExpandedState((prev) => {
       const next =
-        typeof updaterOrValue === 'function' ? (updaterOrValue as (prev: ExpandState) => ExpandState)(prev) : updaterOrValue;
+        typeof updaterOrValue === 'function'
+          ? (updaterOrValue as (prev: ExpandState) => ExpandState)(prev)
+          : updaterOrValue;
       writeToStorage(storageKey, next, storage);
       return next;
     });
-  };
+  }, [storageKey, storage]);
 
-  const toggleNode = (id: string | number) => {
-    setExpanded((prev) => {
-      const key = String(id);
-      const currentState = key in prev ? prev[key] : defaultWhenMissing;
-      return { ...prev, [key]: !currentState };
-    });
-  };
+  const toggleNode = useCallback(
+    (id: string | number) => {
+      setExpanded((prev) => {
+        const key = String(id);
+        const currentState = key in prev ? prev[key] : defaultWhenMissing;
+        return { ...prev, [key]: !currentState };
+      });
+    },
+    [defaultWhenMissing, setExpanded],
+  );
 
   const isNodeExpanded = (id: string | number): boolean => {
     const key = String(id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "krit-ui",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "krit-ui",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "krit-ui",
   "private": true,
-  "version": "0.0.41",
+  "version": "0.0.42",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- Пересобрана ветка от актуального `main` (0.0.41).
- `TreeView`: чекбоксы через `getNodeHeadingPrefix`, настраиваемые линии дерева, `density`, `horizontalPadding`, `striped`, `headerCells`.
- Сохранены `tableRowComponent`, `forwardRef` и `renderFirstColumnHeader` из main.
- `useStoredExpand`: стабилизация обработчиков через `useCallback`.
- Версия пакета: **0.0.42**.

## Test plan
- [ ] Дерево оргролей: чекбоксы, линии, виртуализация, striped.
- [ ] Дерево настроек Toro: `density=compact`, `horizontalPadding=none`.
- [ ] ExecutorsTable: `tableRowComponent` с dnd-kit.
- [ ] MachineryTree / GanttTree: без регрессий.