### PR TITLE
Pagination: добавить настраиваемый набор pageSizeOptions

### DIFF
--- a/lib/components/ui/pagination.tsx
+++ b/lib/components/ui/pagination.tsx
@@ -7,6 +7,8 @@ import LastPage from '@/assets/last_page.svg?react';
 import { Button } from './button';
 import { Select } from './select';
 
+export const DEFAULT_PAGE_SIZE_OPTIONS: number[] = [10, 20, 30, 40, 50] as const;
+
 function PaginationButton({
   active,
   children,
@@ -54,6 +56,8 @@ export interface PaginationProps {
   compact?: boolean;
   /** Скрыть селектор размера страницы */
   hideDisplayBy?: boolean;
+  /** Варианты количества элементов на странице для селектора «Показывать по» */
+  pageSizeOptions?: number[];
   /** Обработчик перехода на предыдущую страницу */
   previousPage?: () => void;
   /** Обработчик перехода на следующую страницу */
@@ -81,6 +85,7 @@ export interface PaginationProps {
  * @param {number} [props.totalCount] - Общее количество элементов
  * @param {boolean} [props.compact=false] - Компактный режим без кнопок первой/последней страницы
  * @param {boolean} [props.hideDisplayBy=false] - Скрыть селектор размера страницы
+ * @param {number[]} [props.pageSizeOptions=DEFAULT_PAGE_SIZE_OPTIONS] - Варианты размера страницы
  * @param {function} [props.previousPage] - Обработчик перехода на предыдущую страницу
  * @param {function} [props.nextPage] - Обработчик перехода на следующую страницу
  * @param {function} [props.setPageSize] - Обработчик изменения размера страницы
@@ -131,6 +136,19 @@ export interface PaginationProps {
  *   previousPage={() => setPageIndex(pageIndex - 1)}
  *   nextPage={() => setPageIndex(pageIndex + 1)}
  * />
+ *
+ * @example
+ * // Кастомные варианты размера страницы
+ * <Pagination
+ *   pageSize={15}
+ *   pageSizeOptions={[5, 15, 25, 100]}
+ *   pageCount={10}
+ *   pageIndex={0}
+ *   canPreviousPage={false}
+ *   canNextPage={true}
+ *   setPageSize={(size) => setPageSize(size)}
+ *   setPageIndex={(index) => setPageIndex(index)}
+ * />
  */
 export function Pagination({
   horizontalPadding,
@@ -144,12 +162,26 @@ export function Pagination({
   totalCount,
   compact,
   hideDisplayBy,
+  pageSizeOptions,
   previousPage,
   nextPage,
   setPageSize,
   setPageIndex,
 }: PaginationProps) {
   const { t } = useTranslation();
+
+  const options = pageSizeOptions ?? DEFAULT_PAGE_SIZE_OPTIONS;
+
+  const resolvedPageSizeOptions =
+    pageSize != null && !options.includes(pageSize)
+      ? [...options, pageSize].sort((a, b) => a - b)
+      : options;
+
+  const selectOptions = resolvedPageSizeOptions.map(size => ({
+    value: String(size),
+    label: `${t('displayBy')} ${size}`,
+  }));
+
   const getCellPadding = () => {
     switch (horizontalPadding) {
       case 'small':
@@ -195,13 +227,7 @@ export function Pagination({
       {!hideDisplayBy && (
         <div className='flex items-center space-x-2'>
           <Select
-            options={[
-              { value: '10', label: `${t('displayBy')} 10` },
-              { value: '20', label: `${t('displayBy')} 20` },
-              { value: '30', label: `${t('displayBy')} 30` },
-              { value: '40', label: `${t('displayBy')} 40` },
-              { value: '50', label: `${t('displayBy')} 50` },
-            ]}
+            options={selectOptions}
             triggerClassName='h-8 text-sm text-foreground-secondary border-none hover:bg-[transparent] px-0'
             placeholder={`${t('displayBy')} ${pageSize}`}
             value={`${pageSize}`}

--- a/lib/stories/Pagination.stories.tsx
+++ b/lib/stories/Pagination.stories.tsx
@@ -56,6 +56,10 @@ const meta: Meta<typeof Pagination> = {
       control: 'boolean',
       description: 'Скрыть селектор размера страницы',
     },
+    pageSizeOptions: {
+      control: 'object',
+      description: 'Варианты количества элементов на странице для селектора «Показывать по»',
+    },
     setPageSize: {
       action: 'setPageSize',
       description: 'Обработчик изменения размера страницы',
@@ -158,6 +162,26 @@ export const Compact: Story = {
   },
 };
 
+// Кастомные варианты размера страницы
+export const CustomPageSizeOptions: Story = {
+  args: {
+    pageSize: 15,
+    pageSizeOptions: [1, 5, 15, 25, 100],
+    pageCount: 10,
+    pageIndex: 0,
+    canPreviousPage: false,
+    canNextPage: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Кастомный набор значений для селектора «Показывать по». По умолчанию используется [10, 20, 30, 40, 50].',
+      },
+    },
+  },
+};
+
 // Без селектора размера страницы
 export const WithoutDisplayBy: Story = {
   args: {
@@ -243,9 +267,7 @@ export const Interactive: Story = {
           <p className='text-sm text-foreground-secondary mb-2'>
             Текущая страница: {pageIndex + 1} из {pageCount}
           </p>
-          <p className='text-sm text-foreground-secondary'>
-            Размер страницы: {pageSize}
-          </p>
+          <p className='text-sm text-foreground-secondary'>Размер страницы: {pageSize}</p>
         </div>
         <Pagination
           pageSize={pageSize}
@@ -300,12 +322,10 @@ export const FullFeatured: Story = {
       <div className='space-y-4'>
         <div className='p-4 bg-background-secondary rounded-lg'>
           <p className='text-sm text-foreground-secondary mb-2'>
-            Страница: {pageIndex + 1} из {pageCount} | Размер: {pageSize} | Всего элементов: {totalCount}
+            Страница: {pageIndex + 1} из {pageCount} | Размер: {pageSize} | Всего элементов:{' '}
+            {totalCount}
           </p>
-          <button
-            onClick={toggleSelection}
-            className='text-sm text-foreground-secondary underline'
-          >
+          <button onClick={toggleSelection} className='text-sm text-foreground-secondary underline'>
             {selectedCount > 0 ? 'Снять выделение' : 'Выделить элементы'}
           </button>
         </div>
@@ -370,7 +390,9 @@ export const EdgeCases: Story = {
         />
       </div>
       <div>
-        <h3 className='text-sm font-medium mb-2'>Четыре страницы (граница отображения многоточия)</h3>
+        <h3 className='text-sm font-medium mb-2'>
+          Четыре страницы (граница отображения многоточия)
+        </h3>
         <Pagination
           pageSize={20}
           pageCount={4}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "krit-ui",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "krit-ui",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "krit-ui",
   "private": true,
-  "version": "0.0.42",
+  "version": "0.0.43",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
Добавлен prop pageSizeOptions для селектора «Показывать по» с дефолтом [10, 20, 30, 40, 50]. Текущий pageSize автоматически включается в список, если его нет среди переданных значений. Добавлена story CustomPageSizeOptions.