### PR TITLE
fix: add native-like mask to TimePicker

### DIFF
--- a/lib/components/ui/time-picker.tsx
+++ b/lib/components/ui/time-picker.tsx
@@ -34,19 +34,17 @@ export interface TimePickerProps extends Omit<InputProps, 'onChange' | 'value' |
  * />
  */
 const TimePicker = React.forwardRef<HTMLInputElement, TimePickerProps>(
-  ({ value, onChange, onBlur, placeholder, className, disabled, readOnly, min, max, ...props }, ref) => {
+  (
+    { value, onChange, onBlur, placeholder = '--:--', className, disabled, readOnly, min, max, ...props },
+    ref,
+  ) => {
     const [open, setOpen] = React.useState(false);
     const isInteractive = !disabled && !readOnly;
 
     const maskedRef = useMask({
-      mask: 'Hh:Mm',
-      replacement: {
-        H: /[0-2]/,
-        h: /[0-9]/,
-        M: /[0-5]/,
-        m: /[0-9]/,
-      },
-      showMask: false,
+      mask: '--:--',
+      replacement: { '-': /\d/ },
+      showMask: true,
     });
 
     const combinedRef = useCombinedRefs(ref, maskedRef);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "krit-ui",
   "private": true,
-  "version": "0.0.49",
+  "version": "0.0.50",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
Show --:-- mask in empty time fields to match native input behavior.