### PR TITLE
Fix npm package install metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@chrome-consulting/krit-ui",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chrome-consulting/krit-ui",
-      "version": "0.0.51",
-      "hasInstallScript": true,
+      "version": "0.0.52",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrome-consulting/krit-ui",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "files": [
     "dist",
@@ -16,7 +16,14 @@
       "require": "./dist/krit-ui.umd.cjs"
     },
     "./dist/style.css": "./dist/style.css",
+    "./style.css": "./dist/style.css",
     "./tailwind.config": "./tailwind.config.cjs"
+  },
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "pack": "npm run build && npm pack",
@@ -28,8 +35,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
-    "postinstall": "npm run build"
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
## Summary
- bump package to 0.0.52
- remove postinstall build script from published package
- restore ./style.css export and CSS sideEffects metadata
- keep publishConfig access public

## Checks
- npm run build
- npm pack --dry-run
- npx eslint lib/components/ui/data-table.tsx lib/components/ui/sortable-header.tsx lib/components/ui/time-picker.tsx lib/stories/DataTable.stories.tsx lib/stories/TimePicker.stories.tsx